### PR TITLE
新型コロナコールセンターのフローカード削除

### DIFF
--- a/components/flow/FlowPcSuspect.vue
+++ b/components/flow/FlowPcSuspect.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="$style.FlowComponent">
-    <div :class="[$style.SubtleBox, $style.Box1]">
+    <div :class="[$style.SubtleBox]">
       <img
         :class="$style.Box1Icon"
         src="/flow/flow_arrow.svg"
@@ -46,27 +46,6 @@
           />
           {{ $t('感染の不安') }}
         </div>
-      </div>
-    </div>
-
-    <div :class="[$style.SubtleBox, $style.Box2, $style.Center]">
-      <div :class="$style.LargerText">
-        {{ $t('新型コロナコールセンター') }}
-      </div>
-      <div :class="$style.SmallerText">
-        {{ $t('24時間対応') }}
-      </div>
-
-      <div :class="$style.Tel">
-        <a :class="$style.TelLink" href="tel:0534536118">
-          <img
-            :class="$style.TelLinkIcon"
-            src="/flow/phone-24px.svg"
-            aria-hidden="true"
-            :alt="$t('電話番号')"
-          />
-          053-453-6118
-        </a>
       </div>
     </div>
   </div>
@@ -150,6 +129,7 @@
   justify-content: space-evenly;
   align-items: center;
   padding: 0.5em;
+  width: 100%;
 }
 
 .Box1 {

--- a/components/flow/FlowSpSuspect.vue
+++ b/components/flow/FlowSpSuspect.vue
@@ -19,21 +19,6 @@
       </li>
     </ul>
 
-    <div :class="$style.callcenter">
-      <p :class="$style.fzLarge">
-        {{ $t('新型コロナコールセンター') }}
-      </p>
-      <p :class="$style.open">
-        {{ $t('24時間対応') }}
-      </p>
-      <p :class="[$style.phone, $style.fzNumeric]">
-        <span :class="$style.icon">
-          <PhoneIcon alt="Phone" />
-        </span>
-        <a href="tel:0534536118">053-453-6118</a>
-      </p>
-    </div>
-
     <a
       v-scroll-to="{
         el: '#consult',


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #35 

## ⛏ 変更内容 / Details of Changes
- フローの内「新型コロナコールセンター」の項目を削除

## 📸 スクリーンショット / Screenshots

#### 変更前（PC）
<img width="721" alt="pc_card_before" src="https://user-images.githubusercontent.com/38583473/77994959-e6d79280-7365-11ea-9493-10fe58a50743.png">

#### 変更後（PC）
<img width="722" alt="pc_card_after" src="https://user-images.githubusercontent.com/38583473/77994993-f525ae80-7365-11ea-943a-678bf4a2bbec.png">

#### 変更前（SP）
<img width="319" alt="sp_card_before" src="https://user-images.githubusercontent.com/38583473/77995040-01117080-7366-11ea-8da7-441400d92aa6.png">

#### 変更後（SP）
<img width="318" alt="sp_card_after" src="https://user-images.githubusercontent.com/38583473/77995056-0969ab80-7366-11ea-9f9e-cfc84817bfbd.png">
