### PR TITLE
Feature/issue 39 page break fix 印刷時のページ改行を追加

### DIFF
--- a/components/flow/FlowPc.vue
+++ b/components/flow/FlowPc.vue
@@ -86,6 +86,10 @@ export default {
   display: flex;
   flex-direction: column;
 
+  @media print {
+    display: block;
+  }
+
   @include card-container();
 
   padding: 20px;
@@ -144,6 +148,13 @@ export default {
     }
 
     margin-bottom: 36px;
+
+    @media print {
+      page-break-after: always;
+      & + h3 {
+        margin-top: 36px;
+      }
+    }
   }
 
   &Lower {

--- a/layouts/print.vue
+++ b/layouts/print.vue
@@ -6,7 +6,7 @@
     </div>
     <v-container v-else>
       <v-row align="center" class="PrintMeta">
-        <v-col :cols="12" :sm="6">
+        <v-col :cols="12" :sm="6" class="PrintMeta-Column">
           <div class="PrintMeta-HeadingWrapper">
             <div class="PrintMeta-Logo">
               <img src="/hamamatsu/logo.svg" :alt="$t('浜松市')" />
@@ -16,7 +16,7 @@
             </h1>
           </div>
         </v-col>
-        <v-col :cols="12" :sm="6">
+        <v-col :cols="12" :sm="6" class="PrintMeta-Column">
           <v-card class="d-flex flex-row" flat tile color="transparent">
             <v-spacer />
             <v-card
@@ -111,6 +111,21 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .PrintMeta {
   margin-bottom: 1em;
+
+  @media print {
+    flex-wrap: nowrap;
+  }
+
+  &-Column {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    @media print {
+      width: auto;
+      flex-basis: auto;
+      flex-grow: 1;
+    }
+  }
 
   &-HeadingWrapper {
     display: flex;


### PR DESCRIPTION
Chromeの印刷改ページ崩れの指摘の修正

## 👏 解決する issue / Resolved Issues
- close #39 

## ⛏ 変更内容 / Details of Changes
- page-break-after: alwaysで見出し前に改行を挿入
- QRコード右のURLが東京都よりも長いために起きていたカラム落ちを修正

## Note
プルリクエスト時の確認ブラウザはGoogle Chrome バージョン: 80.0.3987.162
