### PR TITLE
Hotfix/#3 陽性患者数グラフの更新日時の参照先が間違っている

### DIFF
--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -5,7 +5,7 @@
       :title-id="'number-of-confirmed-cases'"
       :chart-id="'time-bar-chart-patients'"
       :chart-data="patientsGraph"
-      :date="Data.patients.date"
+      :date="Data.patients_summary.date"
       :unit="$t('人')"
       :url="'https://opendata.pref.shizuoka.jp/dataset/8113.html'"
     />


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #3

## ⛏ 変更内容 / Details of Changes
- 陽性患者数の更新日時の参照先が、陽性患者の属性の更新日時となっています。
先週 pull/4しましたが改めてpullしておきます。

