### PR TITLE
hamamatsuプレフィクス除去

### DIFF
--- a/components/flow/FlowSpAdvisory.vue
+++ b/components/flow/FlowSpAdvisory.vue
@@ -16,7 +16,7 @@
           target="_blank"
           rel="noopener noreferrer"
         >
-          {{ $t('hamamatsu.お電話の前に「新型コロナウイルス感染症について」のページをご覧いただき、必要な対応をご検討ください。') }}
+          {{ $t('お電話の前に「新型コロナウイルス感染症について」のページをご覧いただき、必要な対応をご検討ください。') }}
           <v-icon size="16">
             mdi-open-in-new
           </v-icon>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #168 flowページ、スマホ用vueでの翻訳抜け

## ⛏ 変更内容 / Details of Changes
- components/flow/FlowSpAdvisory.vue の翻訳マッチング用キーワードから「hamamatsu.」プレフィクスを除去