### PR TITLE
やさしい日本語でシェアした時のog画像が東京のまま

### DIFF
--- a/assets/locales/ja-Hira.json
+++ b/assets/locales/ja-Hira.json
@@ -261,7 +261,7 @@
   "※最新の情報はWebページをご覧ください": "※新（あたら）しい 情報（じょうほう）は Webページを （見）みてください",
   "〇": "〇",
   "ogp": {
-    "og:image": "https://stopcovid19.metro.tokyo.lg.jp/ogp.png"
+    "og:image": "https://stopcovid19.code4hamamatsu.org/hamamatsu/ogp.png"
   },
   "https://marketingplatform.google.com/about/analytics/terms/jp/": "https://marketingplatform.google.com/about/analytics/terms/jp/",
   "https://policies.google.com/privacy?hl=ja": "https://policies.google.com/privacy?hl=ja",


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #282 

## ⛏ 変更内容 / Details of Changes
やさしいにほんご表示にした状態でシェアした際のog画像が東京のままになってたので修正。