### PR TITLE
グラフのSNS共有ボタンを非表示に

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -63,7 +63,10 @@
           </div>
         </div>
 
-        <div v-if="this.$route.query.embed != 'true'" class="Footer-Right">
+        <div
+          v-if="this.$route.query.embed != 'true' && showEmbedButton"
+          class="Footer-Right"
+        >
           <v-tooltip left nudge-right="20" nudge-bottom="4">
             <template v-slot:activator="{ on }">
               <button
@@ -210,7 +213,8 @@ export default Vue.extend({
       displayShare: false,
       showOverlay: false,
       showDetails: false,
-      openDetails: false
+      openDetails: false,
+      showEmbedButton: false // グラフのSNS共有ボタンの表示制御
     }
   },
   computed: {


### PR DESCRIPTION

## 👏 解決する issue / Resolved Issues
- close #298 

## 📝 関連する issue / Related Issues
- #282 

## ⛏ 変更内容 / Details of Changes

- DataView.vueに`showEmbedButton` プロパティを追加。その値を参照し、SNS共有ボタンの表示制御を行うよう変更