### PR TITLE
最新のお知らせの年が固定になっている件の対策

### DIFF
--- a/tool/create_news_json.py
+++ b/tool/create_news_json.py
@@ -115,8 +115,13 @@ class NewsParser(HTMLParser):
             data = data.strip()
             if data:
                 m = re.match(r'([0-9]{1,2})月([0-9]{1,2})日', data)
-                month, day = m.groups()
-                self.currentDate = "2021/{}/{}".format(month.zfill(2),day.zfill(2))
+                if m:
+                    month, day = m.groups()
+                    self.currentDate = "2021/{}/{}".format(month.zfill(2),day.zfill(2))
+                else:
+                    m = re.match(r'([0-9]{4})年([0-9]{1,2})月([0-9]{1,2})日', data)
+                    year, month, day = m.groups()
+                    self.currentDate = "{}/{}/{}".format(year, month.zfill(2),day.zfill(2))
             return
 
 def main():


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #852 

## ⛏ 変更内容 / Details of Changes
年がなかった場合は今まで通り(2021年固定)
年があった場合はそれを取得する。

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/6513552/104114192-dfa5d200-5344-11eb-8d54-531bf82bbcf3.png)
