### PR TITLE
タガログ語 => フィリピノ語に表記を変更。"Tagalog" => "Filipino"

### DIFF
--- a/nuxt-i18n.config.ts
+++ b/nuxt-i18n.config.ts
@@ -44,10 +44,10 @@ export default {
     },
     {
       code: 'tl-ph',
-      name: 'Tagalog',
+      name: 'Filipino',
       iso: 'tl',
       file: 'tl.json',
-      description: 'Tagalog'
+      description: 'Filipino'
     },
     {
       code: 'zh-cn',


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1002 

## ⛏ 変更内容 / Details of Changes

- 言語選択ボックスのラベルを変更
  - Tagalog => Filipino

## 📸 スクリーンショット / Screenshots

<img width="766" alt="Pinakabagong_video_ng_impeksyon_sa_lunsod___浜松市_新型コロナウイルス感染症対策サイト" src="https://user-images.githubusercontent.com/662084/113586341-57477c80-9668-11eb-8011-b7e11acc4e8f.png">
