### PR TITLE
refs #1132 set node version to 14.17.4 at Github Actions

### DIFF
--- a/.github/workflows/e2etest.yml
+++ b/.github/workflows/e2etest.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [14.17.0]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ $ yarn install
 $ docker-compose run --rm app yarn install
 ```
 
+起動後、[http://localhost:3000](http://localhost:3000) へアクセスする。
+
 ### VSCode + Remote Containersで開発する場合
 
 1. VSCodeの拡張機能「[Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)」を導入します。

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "covid19",
   "version": "1.0.0",
-  "description": "東京都 新型コロナウイルス感染症対策サイト",
-  "author": "東京都",
+  "description": "浜松市 新型コロナウイルス感染症対策サイト",
+  "author": "浜松市",
   "private": true,
   "engines": {
     "node": "14.17.0"


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1132

## ⛏ 変更内容 / Details of Changes

- Github Actionsでのテスト時に使用するNodeのバージョンを14.17.4に固定した
- READMEの記述を追記した
