### PR TITLE
#1177 キャッシュ問題への対応

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -165,6 +165,9 @@ const config: Configuration = {
   pwa: {
     icon: {
       iconSrc: 'static/hamamatsu/icon.png'
+    },
+    workbox: {
+      enabled: false
     }
   },
   generate: {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nuxt/types": "2.15.6",
     "@nuxt/typescript-runtime": "2.1.0",
     "@nuxtjs/dotenv": "^1.4.0",
-    "@nuxtjs/pwa": "^3.0.0-0",
+    "@nuxtjs/pwa": "^3.3.5",
     "@types/d3": "^5.7.2",
     "@types/mapbox-gl": "^1.8.0",
     "chart.js": "2.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1642,7 +1642,7 @@
   dependencies:
     vue-analytics "^5.22.1"
 
-"@nuxtjs/pwa@^3.0.0-0":
+"@nuxtjs/pwa@^3.3.5":
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/@nuxtjs/pwa/-/pwa-3.3.5.tgz#db7c905536ebe8a464a347b6ae3215810642c044"
   integrity sha512-8tTmW8DBspWxlJwTimOHTkwfkwPpL9wIcGmy75Gcmin+c9YtX2Ehxmhgt/TLFOC9XsLAqojqynw3/Agr/9OE1w==


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1177

## ⛏ 変更内容 / Details of Changes
- 東京都の対応を参考に nuxt.config の pwa へ `workbox>enabled:false` を追加

```
pwa: {
  workbox: {
    enabled: false,
  },
},
```
　　参考：https://github.com/tokyo-metropolitan-gov/covid19/pull/6155


- nuxtjs/pwaを最新版にアップデート(3.3.5 : 東京都と同じ)
過去バージョンにはPWAキャッシュに関する不具合があったそうで、
それも今回の症状に影響を与えている可能性もあるため最新版にしておきます。
参考：https://blog.mamansoft.net/2020/12/02/nuxt-pwa-not-updating/

