### PR TITLE
オープンデータ取得先を「ふじのくに」から「浜松市」へ変更 #1307 への対応

### DIFF
--- a/tool/create_data_json.py
+++ b/tool/create_data_json.py
@@ -6,7 +6,7 @@ import logging
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-API_ADDRESS = "https://r4v2wcv8c2.execute-api.ap-northeast-1.amazonaws.com/work/process?type=main_summary:5ab47071-3651-457c-ae2b-bfb8fdbe1af1,main_summary:92f9ebcd-a3f1-4d5d-899b-d69214294a45,patients:5ab47071-3651-457c-ae2b-bfb8fdbe1af1,patients_summary:5ab47071-3651-457c-ae2b-bfb8fdbe1af1,inspection_persons:d4827176-d887-412a-9344-f84f161786a2,contacts:1b57f2c0-081e-4664-ba28-9cce56d0b314"
+API_ADDRESS = "https://r4v2wcv8c2.execute-api.ap-northeast-1.amazonaws.com/work/process2?type=main_summary:221309_hamamatsu_covid19_patients,main_summary:221309_hamamatsu_covid19_patients_summary,patients:221309_hamamatsu_covid19_patients,patients_summary:221309_hamamatsu_covid19_patients,inspection_persons:221309_hamamatsu_covid19_test_people,contacts:221309_hamamatsu_covid19_call_center"
 RETRY_COUNT = 3
 RETRY_WAIT_SEC = 3
 


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1307

## ⛏ 変更内容 / Details of Changes

APIは以下の通りデプロイ済み。
旧 : https://r4v2wcv8c2.execute-api.ap-northeast-1.amazonaws.com/work/process
新 : https://r4v2wcv8c2.execute-api.ap-northeast-1.amazonaws.com/work/process2
(認証キーは同じものをそのまま利用する。)

クエリパタメータとして渡すデータ識別のためのIDが以下のように変更となる。
旧 : type=main_summary:5ab47071-3651-457c-ae2b-bfb8fdbe1af1,main_summary:92f9ebcd-a3f1-4d5d-899b-d69214294a45,patients:5ab47071-3651-457c-ae2b-bfb8fdbe1af1,patients_summary:5ab47071-3651-457c-ae2b-bfb8fdbe1af1,inspection_persons:d4827176-d887-412a-9344-f84f161786a2,contacts:1b57f2c0-081e-4664-ba28-9cce56d0b314
新 : type=main_summary:221309_hamamatsu_covid19_patients,main_summary:221309_hamamatsu_covid19_patients_summary,patients:221309_hamamatsu_covid19_patients,patients_summary:221309_hamamatsu_covid19_patients,inspection_persons:221309_hamamatsu_covid19_test_people,contacts:221309_hamamatsu_covid19_call_center
(データ種別とIDの対応などの詳細は covid19_hamamatsu-opendata_csv2json-goのリポジトリのREADMEを参照。
)

