### PR TITLE
オープンデータ取得先が「ふじのくに」から「浜松市」へ変わったからUIのリンクも変更する #1310 の対応

### DIFF
--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -7,7 +7,9 @@
       :chart-option="{}"
       :date="Data.patients.date"
       :info="sumInfoOfPatients"
-      :url="'https://opendata.pref.shizuoka.jp/dataset/8113.html'"
+      :url="
+        'https://www.city.hamamatsu.shizuoka.jp/odpf/opendata/v1.html?x=221309_hamamatsu_covid19_patients'
+      "
       :source="$t('オープンデータを入手')"
     />
   </v-col>

--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -7,7 +7,9 @@
       :chart-data="patientsGraph"
       :date="Data.patients_summary.date"
       :unit="$t('人')"
-      :url="'https://opendata.pref.shizuoka.jp/dataset/8113.html'"
+      :url="
+        'https://www.city.hamamatsu.shizuoka.jp/odpf/opendata/v1.html?x=221309_hamamatsu_covid19_patients_summary'
+      "
     />
   </v-col>
 </template>

--- a/components/cards/TelephoneAdvisoryReportsNumberCard.vue
+++ b/components/cards/TelephoneAdvisoryReportsNumberCard.vue
@@ -7,7 +7,9 @@
       :chart-data="contactsGraph"
       :date="Data.contacts.date"
       :unit="$t('件.reports')"
-      :url="'https://opendata.pref.shizuoka.jp/dataset/8108.html'"
+      :url="
+        'https://www.city.hamamatsu.shizuoka.jp/odpf/opendata/v1.html?x=221309_hamamatsu_covid19_call_center'
+      "
     />
     <!-- 件.reports = 窓口相談件数 -->
   </v-col>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1310

## ⛏ 変更内容 / Details of Changes
「オープンデータを入手」の遷移先を以下に変更する。
陽性患者の属性：https://www.city.hamamatsu.shizuoka.jp/odpf/opendata/v1.html?x=221309_hamamatsu_covid19_patients
陽性患者数：https://www.city.hamamatsu.shizuoka.jp/odpf/opendata/v1.html?x=221309_hamamatsu_covid19_patients_summary
相談件数：https://www.city.hamamatsu.shizuoka.jp/odpf/opendata/v1.html?x=221309_hamamatsu_covid19_call_center