### PR TITLE
カード下部の日付リンクのリンク切れを修正

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -171,7 +171,39 @@ const config: Configuration = {
     }
   },
   generate: {
-    fallback: true
+    fallback: true,
+    routes() {
+      const locales = [
+        'ja',
+        'ja-basic',
+        'en',
+        'pt-br',
+        'tl',
+        'zh-cn',
+        'vi',
+        'es'
+      ]
+      const pages = [
+        '/cards/details-of-confirmed-cases',
+        '/cards/number-of-confirmed-cases',
+        '/cards/attributes-of-confirmed-cases',
+        '/cards/number-of-inspection-persons',
+        '/cards/number-of-reports-to-covid19-telephone-advisory-center'
+      ]
+
+      const routes: string[] = []
+      locales.forEach(locale => {
+        pages.forEach(page => {
+          if (locale === 'ja') {
+            routes.push(page)
+            return
+          }
+          const route = `/${locale}${page}`
+          routes.push(route)
+        })
+      })
+      return routes
+    }
   },
   // /*
   // ** hot read configuration for docker

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -1,0 +1,105 @@
+<template>
+  <div>
+    <confirmed-cases-details-card
+      v-if="this.$route.params.card == 'details-of-confirmed-cases'"
+    />
+    <confirmed-cases-number-card
+      v-else-if="this.$route.params.card == 'number-of-confirmed-cases'"
+    />
+    <confirmed-cases-attributes-card
+      v-else-if="this.$route.params.card == 'attributes-of-confirmed-cases'"
+    />
+    <inspection-persons-number-card
+      v-else-if="this.$route.params.card == 'number-of-inspection-persons'"
+    />
+    <telephone-advisory-reports-number-card
+      v-else-if="
+        this.$route.params.card ==
+          'number-of-reports-to-covid19-telephone-advisory-center'
+      "
+    />
+  </div>
+</template>
+
+<script>
+import Data from '@/data/hamamatsu/data.json'
+import ConfirmedCasesDetailsCard from '@/components/cards/ConfirmedCasesDetailsCard.vue'
+import ConfirmedCasesNumberCard from '@/components/cards/ConfirmedCasesNumberCard.vue'
+import ConfirmedCasesAttributesCard from '@/components/cards/ConfirmedCasesAttributesCard.vue'
+import InspectionPersonsNumberCard from '@/components/cards/InspectionPersonsNumberCard.vue'
+import TelephoneAdvisoryReportsNumberCard from '@/components/cards/TelephoneAdvisoryReportsNumberCard.vue'
+
+export default {
+  components: {
+    ConfirmedCasesDetailsCard,
+    ConfirmedCasesNumberCard,
+    ConfirmedCasesAttributesCard,
+    InspectionPersonsNumberCard,
+    TelephoneAdvisoryReportsNumberCard
+  },
+  data() {
+    let title, updatedAt
+    switch (this.$route.params.card) {
+      case 'details-of-confirmed-cases':
+        title = this.$t('検査陽性者の状況')
+        updatedAt = Data.inspection_persons.date
+        break
+      case 'number-of-confirmed-cases':
+        title = this.$t('陽性患者数')
+        updatedAt = Data.patients.date
+        break
+      case 'attributes-of-confirmed-cases':
+        title = this.$t('陽性患者の属性')
+        updatedAt = Data.patients.date
+        break
+      case 'number-of-inspection-persons':
+        title = this.$t('検査実施人数')
+        updatedAt = Data.inspection_persons.date
+        break
+      case 'number-of-reports-to-covid19-telephone-advisory-center':
+        title = this.$t('新型コロナウイルス感染症に関する相談件数')
+        updatedAt = Data.contacts.date
+        break
+    }
+
+    const data = {
+      title,
+      updatedAt
+    }
+    return data
+  },
+  head() {
+    const url = 'https://stopcovid19.code4hamamatsu.org'
+    const description = `${this.updatedAt} | ${this.$t(
+      '当サイトは新型コロナウイルス感染症 (COVID-19) に関する最新情報を提供するために、浜松市が開設したものです。'
+    )}`
+
+    return {
+      title: this.title,
+      meta: [
+        {
+          hid: 'og:url',
+          property: 'og:url',
+          content: url + this.$route.path + '/'
+        },
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content:
+            this.title +
+            ' | ' +
+            this.$t('浜松市') +
+            ' ' +
+            this.$t('新型コロナウイルス感染症') +
+            this.$t('対策サイト')
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: description
+        }
+      ]
+    }
+  }
+}
+</script>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues

- close #1551

## ⛏ 変更内容 / Details of Changes

<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->

- https://github.com/code-for-hamamatsu/covid19/pull/1355/commits/41bf9a1a80a5b73bea2ba9ccdb5eaee5defa0f06 の修正で誤って削除されていた設定とコンポーネントを復元
  - そのままだとエラーになる箇所があったので (https://github.com/code-for-hamamatsu/covid19/pull/1552/files#diff-7aa7eb11aaac7ea2129fc21e2e05d464e4c80784d2e36245b9edaf5649ccd3b0R45) これを修正し、かつ不要なコンポーネントへの参照を削除した

## 📸 スクリーンショット / Screenshots

<img width="648" alt="陽性患者数___浜松市_新型コロナウイルス感染症対策サイト" src="https://user-images.githubusercontent.com/662084/183438920-0d0b9958-87f4-4415-9ea5-a2dccf60a0a9.png">

