### PR TITLE
[全数把握の見直し対応] 更新されないデータの見せ方について #1605 への対応（検査陽性者の状況、陽性患者の属性　を非表示）

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -23,8 +23,6 @@
       :btn-text="$t('相談の手順を見る')"
     />
     <v-row class="DataBlock">
-      <confirmed-cases-details-card />
-      <confirmed-cases-attributes-card />
       <confirmed-cases-number-card />
       <inspection-persons-number-card />
       <telephone-advisory-reports-number-card />
@@ -40,9 +38,7 @@ import WhatsNew from '@/components/WhatsNew.vue'
 import StaticInfo from '@/components/StaticInfo.vue'
 import Data from '@/data/hamamatsu/data.json'
 import News from '@/data/hamamatsu/news.json'
-import ConfirmedCasesDetailsCard from '@/components/cards/ConfirmedCasesDetailsCard.vue'
 import ConfirmedCasesNumberCard from '@/components/cards/ConfirmedCasesNumberCard.vue'
-import ConfirmedCasesAttributesCard from '@/components/cards/ConfirmedCasesAttributesCard.vue'
 import InspectionPersonsNumberCard from '@/components/cards/InspectionPersonsNumberCard.vue'
 import TelephoneAdvisoryReportsNumberCard from '@/components/cards/TelephoneAdvisoryReportsNumberCard.vue'
 import { convertDatetimeToISO8601Format } from '@/utils/formatDate'
@@ -52,9 +48,7 @@ export default Vue.extend({
     PageHeader,
     WhatsNew,
     StaticInfo,
-    ConfirmedCasesDetailsCard,
     ConfirmedCasesNumberCard,
-    ConfirmedCasesAttributesCard,
     InspectionPersonsNumberCard,
     TelephoneAdvisoryReportsNumberCard
   },


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #1605

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 検査陽性者の状況、陽性患者の属性　を非表示にしてしまう。

## 📸 スクリーンショット / Screenshots
<img width="767" alt="image" src="https://user-images.githubusercontent.com/6513552/192804391-3abff590-bdb3-4066-8c2e-7613f24af55d.png">
